### PR TITLE
Toml naming change

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ pip install ratchets
 
 You first need to create a tests.toml file at the root of your repository. See [tests.toml](tests.toml) for an example of how this should look. There are two primary rule types that can be defined in the tests.toml file. 
 
-## python-tests
+## ratchet.regex
 
 These are tests that check regular expressions on the basis of each line of each file being examined.
 
 **Example:**
 ```toml
 
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:
@@ -52,7 +52,7 @@ except:
 The valid and invalid entries are not necessary, but we provide a CLI utility, ran with ```python3 -m ratchets.validate```, to verify the regular expressions don't exist in the valid string and do exist in the invalid string. If you are testing the tests.toml file in the current git repository or ```python3 -m ratchets.validate -f FILENAME``` if you need to test a specific toml file.
 
 
-## custom-tests
+## ratchet.shell
 
 These are tests that run against each file where each evaluation is of the form:
 
@@ -66,7 +66,7 @@ It is assumed the standard output of the command describes each of the issues wh
 
 ```toml
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"
 
 ```

--- a/src/ratchets/abstracted_tests.py
+++ b/src/ratchets/abstracted_tests.py
@@ -37,7 +37,7 @@ def get_python_tests() -> Dict[str, Any]:
 
 
 def get_command_tests() -> Dict[str, Any]:
-    """Extract and return the 'ratchets.shell' section from config."""
+    """Extract and return the 'ratchet.shell' section from config."""
     config = get_config()
     shell_tests = config.get("ratchet", {}).get("shell")
     return shell_tests or {}

--- a/src/ratchets/abstracted_tests.py
+++ b/src/ratchets/abstracted_tests.py
@@ -32,7 +32,7 @@ def get_config() -> Dict[str, Any]:
 def get_python_tests() -> Dict[str, Any]:
     """Extract and return the 'python-tests' section from config."""
     config = get_config()
-    return config.get("python-tests", {}) or {}
+    return config.get("ratchet.regex", {}) or {}
 
 
 def get_command_tests() -> Dict[str, Any]:

--- a/src/ratchets/abstracted_tests.py
+++ b/src/ratchets/abstracted_tests.py
@@ -32,13 +32,16 @@ def get_config() -> Dict[str, Any]:
 def get_python_tests() -> Dict[str, Any]:
     """Extract and return the 'python-tests' section from config."""
     config = get_config()
-    return config.get("ratchet.regex", {}) or {}
+    python_tests = config.get("ratchet", {}).get("regex")
+    return python_tests or {}
 
 
 def get_command_tests() -> Dict[str, Any]:
-    """Extract and return the 'custom-tests' section from config."""
+    """Extract and return the 'ratchets.shell' section from config."""
     config = get_config()
-    return config.get("custom-tests", {}) or {}
+    shell_tests = config.get("ratchet", {}).get("shell")
+    return shell_tests or {}
+
 
 
 def load_baseline_counts() -> Dict[str, int]:

--- a/src/ratchets/bad.py
+++ b/src/ratchets/bad.py
@@ -1,0 +1,5 @@
+except:
+except:
+except:
+except:
+except:

--- a/src/ratchets/run_tests.py
+++ b/src/ratchets/run_tests.py
@@ -82,7 +82,7 @@ def evaluate_tests(path: str, cmd_only: bool, regex_only: bool) -> Tuple[Dict[st
 
     config = toml.load(path)
 
-    python_tests = config.get("python-tests")
+    python_tests = config.get("ratchet", {}).get("regex")
     custom_tests = config.get("custom-tests")
     root = find_project_root()
     files = get_python_files(root)

--- a/src/ratchets/run_tests.py
+++ b/src/ratchets/run_tests.py
@@ -83,7 +83,7 @@ def evaluate_tests(path: str, cmd_only: bool, regex_only: bool) -> Tuple[Dict[st
     config = toml.load(path)
 
     python_tests = config.get("ratchet", {}).get("regex")
-    custom_tests = config.get("custom-tests")
+    custom_tests = config.get("ratchet", {}).get("shell")
     root = find_project_root()
     files = get_python_files(root)
     EXCLUDED_PATH = "ratchet_excluded.txt"

--- a/src/ratchets/validate.py
+++ b/src/ratchets/validate.py
@@ -33,7 +33,7 @@ def check_invalid(python_tests: Dict[str, Dict[str, Any]]) -> int:
 def validate(filename : Optional[str]) -> Optional[bool]:
     test_path: str = get_file_path(filename)
     config: Dict[str, Any] = toml.load(test_path)
-    python_tests: Optional[Dict[str, Dict[str, Any]]] = config.get("python-tests")
+    python_tests: Optional[Dict[str, Dict[str, Any]]] = config.get("ratchet", {}).get("regex")
 
     if python_tests is None:
         print("No python tests found, there is nothing to validate.")

--- a/tests.toml
+++ b/tests.toml
@@ -48,5 +48,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests.toml
+++ b/tests.toml
@@ -1,7 +1,7 @@
 # these will be ran in *parallel
 # (gthreads)
 
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:
@@ -25,12 +25,12 @@ except:
     recover()"""
 ]
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/default.toml
+++ b/tests/toml_files/default.toml
@@ -48,5 +48,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/default.toml
+++ b/tests/toml_files/default.toml
@@ -1,7 +1,7 @@
 # these will be ran in *parallel
 # (gthreads)
 
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:
@@ -25,12 +25,12 @@ except:
     recover()"""
 ]
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/different/default_minus_1.toml
+++ b/tests/toml_files/different/default_minus_1.toml
@@ -24,5 +24,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/different/default_minus_1.toml
+++ b/tests/toml_files/different/default_minus_1.toml
@@ -1,12 +1,12 @@
 # these will be ran in *parallel
 # (gthreads)
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/different/default_plus_1.toml
+++ b/tests/toml_files/different/default_plus_1.toml
@@ -3,7 +3,7 @@
 
 
 
-[python-tests.typos]
+[ratchet.regex.typos]
 regex = "rachet|ratchet|rathet|rachet|ratchett"
 valid = [
     """
@@ -18,7 +18,7 @@ invalid = [
 
 
 
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:
@@ -42,12 +42,12 @@ except:
     recover()"""
 ]
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/different/default_plus_1.toml
+++ b/tests/toml_files/different/default_plus_1.toml
@@ -65,5 +65,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/different/entirely_different.toml
+++ b/tests/toml_files/different/entirely_different.toml
@@ -48,5 +48,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/different/entirely_different.toml
+++ b/tests/toml_files/different/entirely_different.toml
@@ -1,7 +1,7 @@
 # these will be ran in *parallel
 # (gthreads)
 
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:
@@ -25,12 +25,12 @@ except:
     recover()"""
 ]
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/invalid.toml
+++ b/tests/toml_files/invalid.toml
@@ -50,5 +50,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/invalid.toml
+++ b/tests/toml_files/invalid.toml
@@ -3,7 +3,7 @@
 
 
 # see missing ] (invalid)
-[python-tests.exceptions
+[ratchet.regex.exceptions
 regex = "except:"
 valid = [
   """try:
@@ -27,12 +27,12 @@ except:
     recover()"""
 ]
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/only-commands.toml
+++ b/tests/toml_files/only-commands.toml
@@ -1,2 +1,2 @@
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/only-python.toml
+++ b/tests/toml_files/only-python.toml
@@ -1,4 +1,4 @@
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:

--- a/tests/toml_files/regexp/invalid/default.toml
+++ b/tests/toml_files/regexp/invalid/default.toml
@@ -48,5 +48,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/regexp/invalid/default.toml
+++ b/tests/toml_files/regexp/invalid/default.toml
@@ -1,7 +1,7 @@
 # these will be ran in *parallel
 # (gthreads)
 
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 invalid = [
   """try:
@@ -25,12 +25,12 @@ except:
     recover()"""
 ]
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/regexp/invalid/only-python.toml
+++ b/tests/toml_files/regexp/invalid/only-python.toml
@@ -1,4 +1,4 @@
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 invalid = [
   """try:

--- a/tests/toml_files/regexp/valid/default.toml
+++ b/tests/toml_files/regexp/valid/default.toml
@@ -48,5 +48,5 @@ invalid = [
 # these can be tested by running echo FILEPATH | COMMAND
 # these will be ran in parallel
 
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/regexp/valid/default.toml
+++ b/tests/toml_files/regexp/valid/default.toml
@@ -1,7 +1,7 @@
 # these will be ran in *parallel
 # (gthreads)
 
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:
@@ -25,12 +25,12 @@ except:
     recover()"""
 ]
 
-[python-tests.lightning]
+[ratchet.regex.lightning]
 regex = "import pytorch_lightning|from pytorch_lightning"
 valid = ["import torch", "from my_project import Trainer"]
 invalid = ["import pytorch_lightning", "from pytorch_lightning import LightningModule"]
 
-[python-tests.tabs]
+[ratchet.regex.tabs]
 regex = "\\t"
 valid = [
   """def foo():

--- a/tests/toml_files/regexp/valid/only-commands.toml
+++ b/tests/toml_files/regexp/valid/only-commands.toml
@@ -1,2 +1,2 @@
-[custom-tests.line_too_long]
+[ratchet.shell.line_too_long]
 command = "xargs -n1 awk 'length($0) > 80'"

--- a/tests/toml_files/regexp/valid/only-python.toml
+++ b/tests/toml_files/regexp/valid/only-python.toml
@@ -1,4 +1,4 @@
-[python-tests.exceptions]
+[ratchet.regex.exceptions]
 regex = "except:"
 valid = [
   """try:


### PR DESCRIPTION
Update toml schema:

- python-tests -> ratchet.regex
- custom-tests -> ratchet.shell

This does not update all naming throughout (variable names / comments and such), but everything functional has been updated to support the schema change. I am putting this in main because I don't have more time to work on this and the schema change suggestion was a good one. 